### PR TITLE
Fix for updated firmwares without root access

### DIFF
--- a/build_uce_tool.py
+++ b/build_uce_tool.py
@@ -58,7 +58,9 @@ def call_mksquashfs(input_dir, target_file, app_root):
         input_dir,
         target_file,
         '-b', '262144',
-        '-root-owned',
+        '-force-uid', '12',
+        '-force-gid', '12',
+        '-noappend',
         '-nopad'
     ]
     if common_utils.get_platform() == 'win32':


### PR DESCRIPTION
Force the uid/gid to the guest uid/gid. This is backwards compatible as root can read/write all files/dirs regardless of perms. UCEs built using these new xattrs should continue to work on older systems.

Also adding the -noappend option which will recreate UCE's that already exist instead of updating them in-place.